### PR TITLE
Add span field to SpanLogs to support sampling of span logs

### DIFF
--- a/java-lib/src/main/avro/Reporting.avdl
+++ b/java-lib/src/main/avro/Reporting.avdl
@@ -64,6 +64,20 @@ protocol Reporting {
     union{null, string} spanSecondaryId = null;
     // span log entries
     array<SpanLog> logs;
+    // span in line data format, for sampling and filterings
+    union{null, string} span = null;
+  }
+
+  record SpanLogsDAO {
+    string customer;
+    // uuid of the trace
+    string traceId;
+    // uuid of the span
+    string spanId;
+    // alternative span ID
+    union{null, string} spanSecondaryId = null;
+    // span log entries
+    array<SpanLog> logs;
   }
 
 // Collection of spans with the same traceId.

--- a/java-lib/src/main/avro/Reporting.avdl
+++ b/java-lib/src/main/avro/Reporting.avdl
@@ -68,18 +68,6 @@ protocol Reporting {
     union{null, string} span = null;
   }
 
-  record SpanLogsDAO {
-    string customer;
-    // uuid of the trace
-    string traceId;
-    // uuid of the span
-    string spanId;
-    // alternative span ID
-    union{null, string} spanSecondaryId = null;
-    // span log entries
-    array<SpanLog> logs;
-  }
-
 // Collection of spans with the same traceId.
   record Trace {
   // uuid of the trace

--- a/java-lib/src/main/java/com/wavefront/ingester/SpanLogsDecoder.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/SpanLogsDecoder.java
@@ -53,6 +53,7 @@ public class SpanLogsDecoder implements ReportableEntityDecoder<JsonNode, SpanLo
                 setFields(JSON_PARSER.convertValue(x.get("fields"), Map.class)).
                 build()
             ).collect(Collectors.toList())).
+        setSpan(msg.get("span") == null ? null : msg.get("span").textValue()).
         build();
     if (out != null) {
       out.add(spanLogs);

--- a/java-lib/src/main/java/com/wavefront/ingester/SpanLogsSerializer.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/SpanLogsSerializer.java
@@ -1,0 +1,48 @@
+package com.wavefront.ingester;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import wavefront.report.SpanLog;
+import wavefront.report.SpanLogs;
+
+import java.util.function.Function;
+import java.util.logging.Logger;
+
+/**
+ * Convert {@link SpanLogs} to its string representation in a canonical format.
+ *
+ * @author Han Zhang (zhanghan@vmware.com)
+ */
+public class SpanLogsSerializer implements Function<SpanLogs, String> {
+  private static final Logger logger =
+      Logger.getLogger(SpanLogsSerializer.class.getCanonicalName());
+
+  private static final ObjectMapper JSON_PARSER = new ObjectMapper();
+
+  static {
+    JSON_PARSER.addMixIn(SpanLogs.class, IgnoreSchemaProperty.class);
+    JSON_PARSER.addMixIn(SpanLog.class, IgnoreSchemaProperty.class);
+  }
+
+  @Override
+  public String apply(SpanLogs spanLogs) {
+    return spanLogsToString(spanLogs);
+  }
+
+  @VisibleForTesting
+  static String spanLogsToString(SpanLogs spanLogs) {
+    try {
+      return JSON_PARSER.writeValueAsString(spanLogs);
+    } catch (JsonProcessingException e) {
+      logger.warning("Serialization error!");
+      return null;
+    }
+  }
+
+  abstract static class IgnoreSchemaProperty {
+    @JsonIgnore
+    abstract void getSchema();
+  }
+}

--- a/java-lib/src/test/java/com/wavefront/ingester/SpanLogsDecoderTest.java
+++ b/java-lib/src/test/java/com/wavefront/ingester/SpanLogsDecoderTest.java
@@ -41,6 +41,7 @@ public class SpanLogsDecoderTest {
     assertEquals(2, out.get(0).getLogs().get(0).getFields().size());
     assertEquals("error", out.get(0).getLogs().get(0).getFields().get("event"));
     assertEquals("exception", out.get(0).getLogs().get(0).getFields().get("error.kind"));
+    assertNull(out.get(0).getSpan());
   }
 
   @Test
@@ -64,5 +65,38 @@ public class SpanLogsDecoderTest {
     assertEquals(2, out.get(0).getLogs().get(0).getFields().size());
     assertEquals("error", out.get(0).getLogs().get(0).getFields().get("event"));
     assertEquals("exception", out.get(0).getLogs().get(0).getFields().get("error.kind"));
+    assertNull(out.get(0).getSpan());
+  }
+
+  @Test
+  public void testDecodeWithSpan() throws IOException {
+    List<SpanLogs> out = new ArrayList<>();
+    String msg = "{" +
+        "\"customer\":\"default\"," +
+        "\"traceId\":\"7b3bf470-9456-11e8-9eb6-529269fb1459\"," +
+        "\"spanId\":\"0313bafe-9457-11e8-9eb6-529269fb1459\"," +
+        "\"logs\":[{\"timestamp\":1554363517965,\"fields\":{\"event\":\"error\",\"error.kind\":\"exception\"}}]," +
+        "\"span\":\"\\\"testSpanName\\\" \\\"source\\\"=\\\"spanSource\\\" " +
+          "\\\"spanId\\\"=\\\"4217104a-690d-4927-baff-d9aa779414c2\\\" " +
+          "\\\"traceId\\\"=\\\"d5355bf7-fc8d-48d1-b761-75b170f396e0\\\" " +
+          "\\\"tagkey1\\\"=\\\"tagvalue1\\\" \\\"t2\\\"=\\\"v2\\\" 1532012145123 1532012146234\"" +
+        "}";
+
+    decoder.decode(jsonParser.readTree(msg), out, "testCustomer");
+    assertEquals(1, out.size());
+    assertEquals("testCustomer", out.get(0).getCustomer());
+    assertEquals("7b3bf470-9456-11e8-9eb6-529269fb1459", out.get(0).getTraceId());
+    assertEquals("0313bafe-9457-11e8-9eb6-529269fb1459", out.get(0).getSpanId());
+    assertNull(out.get(0).getSpanSecondaryId());
+    assertEquals(1, out.get(0).getLogs().size());
+    assertEquals(1554363517965L, out.get(0).getLogs().get(0).getTimestamp().longValue());
+    assertEquals(2, out.get(0).getLogs().get(0).getFields().size());
+    assertEquals("error", out.get(0).getLogs().get(0).getFields().get("event"));
+    assertEquals("exception", out.get(0).getLogs().get(0).getFields().get("error.kind"));
+    assertEquals("\"testSpanName\" \"source\"=\"spanSource\" " +
+        "\"spanId\"=\"4217104a-690d-4927-baff-d9aa779414c2\" " +
+        "\"traceId\"=\"d5355bf7-fc8d-48d1-b761-75b170f396e0\" " +
+        "\"tagkey1\"=\"tagvalue1\" \"t2\"=\"v2\" 1532012145123 1532012146234",
+        out.get(0).getSpan());
   }
 }

--- a/java-lib/src/test/java/com/wavefront/ingester/SpanLogsSerializerTest.java
+++ b/java-lib/src/test/java/com/wavefront/ingester/SpanLogsSerializerTest.java
@@ -1,0 +1,89 @@
+package com.wavefront.ingester;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import wavefront.report.SpanLog;
+import wavefront.report.SpanLogs;
+
+import java.util.function.Function;
+
+/**
+ * Tests for {@link SpanLogsSerializer}.
+ *
+ * @author Han Zhang (zhanghan@vmware.com)
+ */
+public class SpanLogsSerializerTest {
+
+  private Function<SpanLogs, String> serializer = new SpanLogsSerializer();
+
+  @Test
+  public void testSpanLogsToString() {
+    SpanLogs spanLogs = SpanLogs.newBuilder()
+        .setCustomer("dummy")
+        .setTraceId("d5355bf7-fc8d-48d1-b761-75b170f396e0")
+        .setSpanId("4217104a-690d-4927-baff-d9aa779414c2")
+        .setLogs(ImmutableList.of(new SpanLog(1554363517965L, ImmutableMap.of("event", "error",
+            "error.kind", "exception"))))
+        .build();
+    assertEquals("{" +
+        "\"customer\":\"dummy\"," +
+        "\"traceId\":\"d5355bf7-fc8d-48d1-b761-75b170f396e0\"," +
+        "\"spanId\":\"4217104a-690d-4927-baff-d9aa779414c2\"," +
+        "\"spanSecondaryId\":null," +
+        "\"logs\":[{\"timestamp\":1554363517965,\"fields\":{\"event\":\"error\",\"error.kind\":\"exception\"}}]," +
+        "\"span\":null" +
+        "}",
+        serializer.apply(spanLogs));
+  }
+
+  @Test
+  public void testSpanLogsToStringWithSpanSecondaryId() {
+    SpanLogs spanLogs = SpanLogs.newBuilder()
+        .setCustomer("dummy")
+        .setTraceId("d5355bf7-fc8d-48d1-b761-75b170f396e0")
+        .setSpanId("4217104a-690d-4927-baff-d9aa779414c2")
+        .setSpanSecondaryId("server")
+        .setLogs(ImmutableList.of(new SpanLog(1554363517965L, ImmutableMap.of("event", "error",
+            "error.kind", "exception"))))
+        .build();
+    assertEquals("{" +
+            "\"customer\":\"dummy\"," +
+            "\"traceId\":\"d5355bf7-fc8d-48d1-b761-75b170f396e0\"," +
+            "\"spanId\":\"4217104a-690d-4927-baff-d9aa779414c2\"," +
+            "\"spanSecondaryId\":\"server\"," +
+            "\"logs\":[{\"timestamp\":1554363517965,\"fields\":{\"event\":\"error\",\"error.kind\":\"exception\"}}]," +
+            "\"span\":null" +
+            "}",
+        serializer.apply(spanLogs));
+  }
+
+  @Test
+  public void testSpanLogsToStringWithSpan() {
+    SpanLogs spanLogs = SpanLogs.newBuilder()
+        .setCustomer("dummy")
+        .setTraceId("d5355bf7-fc8d-48d1-b761-75b170f396e0")
+        .setSpanId("4217104a-690d-4927-baff-d9aa779414c2")
+        .setLogs(ImmutableList.of(new SpanLog(1554363517965L, ImmutableMap.of("event", "error",
+            "error.kind", "exception"))))
+        .setSpan("\"testSpanName\" \"source\"=\"spanSource\" " +
+            "\"spanId\"=\"4217104a-690d-4927-baff-d9aa779414c2\" " +
+            "\"traceId\"=\"d5355bf7-fc8d-48d1-b761-75b170f396e0\" " +
+            "\"tagkey1\"=\"tagvalue1\" \"t2\"=\"v2\" 1532012145123 1532012146234")
+        .build();
+    assertEquals("{" +
+        "\"customer\":\"dummy\"," +
+        "\"traceId\":\"d5355bf7-fc8d-48d1-b761-75b170f396e0\"," +
+        "\"spanId\":\"4217104a-690d-4927-baff-d9aa779414c2\"," +
+        "\"spanSecondaryId\":null," +
+        "\"logs\":[{\"timestamp\":1554363517965,\"fields\":{\"event\":\"error\",\"error.kind\":\"exception\"}}]," +
+        "\"span\":\"\\\"testSpanName\\\" \\\"source\\\"=\\\"spanSource\\\" " +
+          "\\\"spanId\\\"=\\\"4217104a-690d-4927-baff-d9aa779414c2\\\" " +
+          "\\\"traceId\\\"=\\\"d5355bf7-fc8d-48d1-b761-75b170f396e0\\\" " +
+          "\\\"tagkey1\\\"=\\\"tagvalue1\\\" \\\"t2\\\"=\\\"v2\\\" 1532012145123 1532012146234\"" +
+        "}",
+        serializer.apply(spanLogs));
+  }
+}


### PR DESCRIPTION
Spans can get sampled based on the presence of debug/error tags (and they can also be filtered by proxy preprocessor rules).  In order to support the sampling of span logs based on the same criteria, I'm adding the span (as a String instead of an object, because the proxy can do preprocessing on the string representation of the span first) to the SpanLogs object.

Also refactored the span logs serializer out of proxy and added SpanLogsDAO so that the schema for data storage/access does not change.