### PR TITLE
MONIT-24888: Span log is not returned from UI

### DIFF
--- a/java-lib/src/main/java/com/wavefront/ingester/SpanLogsDecoder.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/SpanLogsDecoder.java
@@ -45,7 +45,8 @@ public class SpanLogsDecoder implements ReportableEntityDecoder<JsonNode, SpanLo
         setCustomer(customerId).
         setTraceId(msg.get("traceId") == null ? null : msg.get("traceId").textValue()).
         setSpanId(msg.get("spanId") == null ? null : msg.get("spanId").textValue()).
-        setSpanSecondaryId(msg.get("spanSecondaryId") == null ? null :
+        setSpanSecondaryId(msg.get("spanSecondaryId") == null ? (msg.get("_spanSecondaryId") == null ? null :
+            msg.get("_spanSecondaryId").textValue()) :
             msg.get("spanSecondaryId").textValue()).
         setLogs(StreamSupport.stream(iterable.spliterator(), false).
             map(x -> SpanLog.newBuilder().

--- a/java-lib/src/test/java/com/wavefront/ingester/SpanLogsDecoderTest.java
+++ b/java-lib/src/test/java/com/wavefront/ingester/SpanLogsDecoderTest.java
@@ -45,6 +45,30 @@ public class SpanLogsDecoderTest {
   }
 
   @Test
+  public void testDecodeInternalSpanSecondaryId() throws IOException {
+    List<SpanLogs> out = new ArrayList<>();
+    String msg = "{" +
+        "\"customer\":\"default\"," +
+        "\"traceId\":\"7b3bf470-9456-11e8-9eb6-529269fb1459\"," +
+        "\"spanId\":\"0313bafe-9457-11e8-9eb6-529269fb1459\"," +
+        "\"_spanSecondaryId\":\"client\"," +
+        "\"logs\":[{\"timestamp\":1554363517965,\"fields\":{\"event\":\"error\",\"error.kind\":\"exception\"}}]}";
+
+    decoder.decode(jsonParser.readTree(msg), out, "testCustomer");
+    assertEquals(1, out.size());
+    assertEquals("testCustomer", out.get(0).getCustomer());
+    assertEquals("7b3bf470-9456-11e8-9eb6-529269fb1459", out.get(0).getTraceId());
+    assertEquals("0313bafe-9457-11e8-9eb6-529269fb1459", out.get(0).getSpanId());
+    assertEquals("client", out.get(0).getSpanSecondaryId());
+    assertEquals(1, out.get(0).getLogs().size());
+    assertEquals(1554363517965L, out.get(0).getLogs().get(0).getTimestamp());
+    assertEquals(2, out.get(0).getLogs().get(0).getFields().size());
+    assertEquals("error", out.get(0).getLogs().get(0).getFields().get("event"));
+    assertEquals("exception", out.get(0).getLogs().get(0).getFields().get("error.kind"));
+    assertNull(out.get(0).getSpan());
+  }
+
+  @Test
   public void testDecodeWithSpanSecondaryId() throws IOException {
     List<SpanLogs> out = new ArrayList<>();
     String msg = "{" +


### PR DESCRIPTION
In wavefront code bases, "_spanSecondaryId" tag are referenced and in java-lib Validation class (not called). Proxy code and spring boot code are tagged with "_spanSecondaryId". However the decoding part only expects "spanSecondaryId" which leads to spanlog side has no "spanSecondaryId". This change is to process span using "spanSecondaryId" first if absent fallback to "_spanSecondaryId".