### PR TITLE
Fix WF-428 error message for span name length

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ["11", "16", "17"]
+        java: ["11", "17"]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java }}

--- a/java-lib/pom.xml
+++ b/java-lib/pom.xml
@@ -61,6 +61,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
     </dependency>

--- a/java-lib/src/main/java/com/wavefront/data/Validation.java
+++ b/java-lib/src/main/java/com/wavefront/data/Validation.java
@@ -381,7 +381,7 @@ public class Validation {
     }
     if (spanName.length() > config.getSpanLengthLimit()) {
       ERROR_COUNTERS.get("spanNameTooLong").inc();
-      throw new DataValidationException("WF-428: Span name is too long (" + source.length() +
+      throw new DataValidationException("WF-428: Span name is too long (" + spanName.length() +
           " characters, max: " + config.getSpanLengthLimit() + "): " + spanName);
     }
     if (spanName.contains("*")) {

--- a/java-lib/src/test/java/com/wavefront/data/ValidationTest.java
+++ b/java-lib/src/test/java/com/wavefront/data/ValidationTest.java
@@ -4,8 +4,8 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 
 import com.wavefront.api.agent.ValidationConfiguration;
-import com.wavefront.ingester.ReportMetricDecoder;
 import com.wavefront.ingester.ReportHistogramDecoder;
+import com.wavefront.ingester.ReportMetricDecoder;
 import com.wavefront.ingester.SpanDecoder;
 
 import org.junit.Assert;
@@ -23,6 +23,8 @@ import wavefront.report.Span;
 import wavefront.report.SpanLogs;
 import wavefront.report.ReportLog;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -417,6 +419,7 @@ public class ValidationTest {
       fail();
     } catch (IllegalArgumentException iae) {
       assertTrue(iae.getMessage().contains("WF-428"));
+      assertThat(iae.getMessage(), containsString(span.getName().length() + " characters, max: 20"));
     }
 
     // span has too many annotations: WF-430
@@ -579,7 +582,7 @@ public class ValidationTest {
   public void testValidHistogram() {
     ReportHistogramDecoder decoder = new ReportHistogramDecoder();
     List<ReportHistogram> out = new ArrayList<>();
-    decoder.decode("!M 1533849540 #1 0.0 #2 1.0 #3 3.0 TestMetric source=Test key=value", out, 
+    decoder.decode("!M 1533849540 #1 0.0 #2 1.0 #3 3.0 TestMetric source=Test key=value", out,
         "dummy");
     Validation.validateHistogram(out.get(0), new ValidationConfiguration());
   }

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <!-- Testing library versions -->
     <junit.version>4.13.1</junit.version>
     <truth.version>0.29</truth.version>
+    <hamcrest.version>1.3</hamcrest.version>
 
     <!-- target java 8 compatibility -->
     <java.version>1.8</java.version>
@@ -184,6 +185,12 @@
         <groupId>com.google.truth</groupId>
         <artifactId>truth</artifactId>
         <version>${truth.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-all</artifactId>
+        <version>${hamcrest.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
This fixes an incorrect error message about span name length. It was first reported by a user of the WF proxy, which uses `Validation.java`.