### PR TITLE
feat: Add syslog decoder, formatter, and parser

### DIFF
--- a/java-lib/pom.xml
+++ b/java-lib/pom.xml
@@ -39,6 +39,11 @@
       <artifactId>commons-collections</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.integration</groupId>
+      <artifactId>spring-integration-syslog</artifactId>
+      <version>5.5.15</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/java-lib/src/main/java/com/wavefront/ingester/SyslogDecoder.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/SyslogDecoder.java
@@ -1,0 +1,54 @@
+package com.wavefront.ingester;
+
+import javax.annotation.Nullable;
+
+import org.springframework.integration.syslog.RFC5424SyslogParser;
+import wavefront.report.Annotation;
+import wavefront.report.ReportLog;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SyslogDecoder implements ReportableEntityDecoder<String, ReportLog> {
+    private static final AbstractIngesterFormatter<ReportLog> FORMAT =
+            SyslogIngesterFormatter.newBuilder().build();
+
+    private final Supplier<String> hostNameSupplier;
+    private List<String> customSourceTags;
+    private List<String> customLogTimestampTags;
+    private List<String> customLogMessageTags;
+    private List<String> customApplicationTags;
+    private List<String> customServiceTags;
+    private List<String> customLevelTags;
+    private List<String> customExceptionTags;
+
+    public SyslogDecoder(@Nullable Supplier<String> hostNameSupplier,
+                         List<String> customSourceTags, List<String> customLogTimestampTags, List<String> customLogMessageTags,
+                         List<String> customApplicationTags, List<String> customServiceTags,
+                         List<String> customLevelTags, List<String> customExceptionTags) {
+        this.hostNameSupplier = hostNameSupplier;
+        this.customSourceTags = customSourceTags;
+        this.customLogTimestampTags = customLogTimestampTags;
+        this.customLogMessageTags = customLogMessageTags;
+        this.customApplicationTags = customApplicationTags;
+        this.customServiceTags = customServiceTags;
+        this.customLevelTags = customLevelTags;
+        this.customExceptionTags = customExceptionTags;
+    }
+
+    @Override
+    public void decode(String msg, List<ReportLog> out, String customerId, @Nullable IngesterContext ctx) {
+        ReportLog log = FORMAT.drive(msg, hostNameSupplier, "default", customSourceTags, customLogTimestampTags,
+                customLogMessageTags, customApplicationTags, customServiceTags, customLevelTags, customExceptionTags, ctx);
+
+        if (out != null) {
+            out.add(log);
+        }
+    }
+}

--- a/java-lib/src/main/java/com/wavefront/ingester/SyslogIngesterFormatter.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/SyslogIngesterFormatter.java
@@ -1,0 +1,108 @@
+package com.wavefront.ingester;
+
+import com.wavefront.data.ParseException;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.integration.syslog.SyslogHeaders;
+import wavefront.report.Annotation;
+import wavefront.report.ReportLog;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class SyslogIngesterFormatter extends AbstractIngesterFormatter<ReportLog> {
+    private final String NONE = "none";
+    private final String APPLICATION = "application";
+    private final String SERVICE = "service";
+    private final String LOG_LEVEL = "log_level";
+    private final String ERROR_NAME = "error_name";
+
+    private final String SYSLOG_HOST = "syslog_host";
+
+    private static final String NILVALUE = "-";
+
+    private final SyslogParser parser = new SyslogParser();
+
+    private SyslogIngesterFormatter(List<FormatterElement<ReportLog>> elements) {
+        super(elements);
+    }
+
+    public static class ReportLogIngesterFormatBuilder extends IngesterFormatBuilder<ReportLog> {
+        @Override
+        public SyslogIngesterFormatter build() {
+            return new SyslogIngesterFormatter(elements);
+        }
+    }
+
+    public static IngesterFormatBuilder<ReportLog> newBuilder() {
+        return new ReportLogIngesterFormatBuilder();
+    }
+
+    // Doesn't support customLogTimestampTags and customLogMessageTags
+    // due to the syslog parsing library not currently supporting those cases
+    @Override
+    public ReportLog drive(
+            String syslogMessage,
+            @Nullable Supplier<String> defaultHostNameSupplier,
+            String customerId,
+            @Nullable List<String> customSourceTags,
+            @Nullable List<String> customLogTimestampTags,
+            @Nullable List<String> customLogMessageTags,
+            List<String> customLogApplicationTags,
+            List<String> customLogServiceTags,
+            @Nullable List<String> customLogLevelTags,
+            @Nullable List<String> customLogExceptionTags,
+            @Nullable IngesterContext ingesterContext) {
+        final ReportLog log = new ReportLog();
+        List<Annotation> annotations = new ArrayList<>();
+
+        try {
+            parser.parse(syslogMessage, annotations);
+            log.setAnnotations(annotations);
+
+            String host = AbstractIngesterFormatter.getHostAndNormalizeTags(log.getAnnotations(), customSourceTags, false);
+            if (host == null) {
+                if (defaultHostNameSupplier == null) {
+                    host = "unknown";
+                } else {
+                    host = defaultHostNameSupplier.get();
+                }
+            }
+            log.setHost(host);
+
+            // Will always be the timestamp from the syslog message as our syslog parsing library doesn't support it being nil
+            Long timestamp = AbstractIngesterFormatter.getLogTimestamp(log.getAnnotations(), null);
+            log.setTimestamp(timestamp);
+
+            // Will always be the message from the syslog message as our syslog parsing library doesn't support it being nil
+            String message = AbstractIngesterFormatter.getLogMessage(log.getAnnotations(), customLogMessageTags);
+            log.setMessage(message);
+
+            String application = AbstractIngesterFormatter.getLogApplication(log.getAnnotations(), customLogApplicationTags);
+            if (!StringUtils.equalsIgnoreCase(application, NONE)) {
+                log.getAnnotations().add(Annotation.newBuilder().setKey(APPLICATION).setValue(application).build());
+            }
+
+            String service = AbstractIngesterFormatter.getLogService(log.getAnnotations(), customLogServiceTags);
+            if (!StringUtils.equalsIgnoreCase(service, NONE)) {
+                log.getAnnotations().add(Annotation.newBuilder().setKey(SERVICE).setValue(service).build());
+            }
+
+            String level = AbstractIngesterFormatter.getLogLevel(log.getAnnotations(), customLogLevelTags);
+            if (!StringUtils.equalsIgnoreCase(level, "")) {
+                log.getAnnotations().add(Annotation.newBuilder().setKey(LOG_LEVEL).setValue(level).build());
+            }
+
+            String exception = AbstractIngesterFormatter.getLogException(log.getAnnotations(), customLogExceptionTags);
+            if (!StringUtils.equalsIgnoreCase(exception, "")) {
+                log.getAnnotations().add(Annotation.newBuilder().setKey(ERROR_NAME).setValue(exception).build());
+            }
+
+            return log;
+        } catch (ParseException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/java-lib/src/main/java/com/wavefront/ingester/SyslogParser.java
+++ b/java-lib/src/main/java/com/wavefront/ingester/SyslogParser.java
@@ -1,0 +1,85 @@
+package com.wavefront.ingester;
+
+import com.wavefront.data.ParseException;
+import org.springframework.integration.syslog.RFC5424SyslogParser;
+import org.springframework.integration.syslog.SyslogHeaders;
+import wavefront.report.Annotation;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+// Doesn't support nil values for the timestamp and message syslog fields
+// due to the syslog parsing library not currently supporting those cases
+public class SyslogParser {
+    private static final String NILVALUE = "-";
+
+    private final RFC5424SyslogParser parser = new RFC5424SyslogParser();
+
+    private Pattern structuredDataTagRegex;
+
+    public SyslogParser() {
+        structuredDataTagRegex = Pattern.compile(" (?:([^=]+)=\\\"([^\\\"]*)\\\")");
+    }
+
+    public void parse(String syslogMessage, List<Annotation> annotations) {
+        char firstChar = syslogMessage.charAt(0);
+        if (firstChar != '<' && java.lang.Character.isDigit(firstChar)) {
+            int whiteSpaceIndex = syslogMessage.indexOf(' ');
+            int octetCount = Integer.parseInt(syslogMessage.substring(0, whiteSpaceIndex));
+            syslogMessage = syslogMessage.substring(whiteSpaceIndex);
+
+            // Octet count is a count of the entire message including the space
+            if (syslogMessage.getBytes(StandardCharsets.UTF_8).length != octetCount) {
+                throw new ParseException("Mismatched syslog message octet count");
+            }
+
+            // Syslog message starts after the octet count and space
+            int lessthanIndex = syslogMessage.indexOf('<');
+            syslogMessage = syslogMessage.substring(lessthanIndex);
+        }
+
+        Map<String, ?> fields = parser.parse(syslogMessage, 0, false);
+
+        if (fields.get(SyslogHeaders.DECODE_ERRORS).toString().equals("true")) {
+            throw new ParseException(fields.get(SyslogHeaders.ERRORS).toString());
+        }
+
+        if (fields.get(SyslogHeaders.TIMESTAMP) == null) {
+            throw new ParseException("Timestamp is a required syslog field");
+        }
+
+        String logTimestamp = fields.get(SyslogHeaders.TIMESTAMP).toString();
+        Instant timestamp = ZonedDateTime.parse(logTimestamp).toInstant();
+        long timestampEpochMilliSecond = timestamp.toEpochMilli();
+        annotations.add(Annotation.newBuilder().setKey("timestamp").setValue(Long.toString(timestampEpochMilliSecond)).build());
+
+        if (fields.get(SyslogHeaders.MESSAGE) == null) {
+            throw new ParseException("Message is a required syslog field");
+        }
+
+        String logMessage = fields.get(SyslogHeaders.MESSAGE).toString();
+        annotations.add(Annotation.newBuilder().setKey("message").setValue(logMessage).build());
+
+        String host = fields.get(SyslogHeaders.HOST).toString();
+        if (!NILVALUE.equals(fields.get(SyslogHeaders.HOST).toString())) {
+            annotations.add(Annotation.newBuilder().setKey("host").setValue(host).build());
+        }
+
+        // Adding as a separate tag so we still have access to it as a tag
+        annotations.add(Annotation.newBuilder().setKey("syslog_host").setValue(host).build());
+
+        if (fields.get(SyslogHeaders.STRUCTURED_DATA) != null) {
+            String structuredData = fields.get(SyslogHeaders.STRUCTURED_DATA).toString();
+            Matcher m = structuredDataTagRegex.matcher(structuredData);
+
+            while (m.find()) {
+                annotations.add(Annotation.newBuilder().setKey(m.group(1)).setValue(m.group(2)).build());
+            }
+        }
+    }
+}

--- a/java-lib/src/test/java/com/wavefront/ingester/SyslogDecoderTest.java
+++ b/java-lib/src/test/java/com/wavefront/ingester/SyslogDecoderTest.java
@@ -1,0 +1,211 @@
+package com.wavefront.ingester;
+
+import com.wavefront.common.Clock;
+import org.junit.Before;
+import org.junit.Test;
+import wavefront.report.Annotation;
+import wavefront.report.ReportLog;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Collections;
+import java.util.function.Supplier;
+
+import static junit.framework.TestCase.*;
+
+public class SyslogDecoderTest {
+    private final String defaultHost = "unitTest";
+    private final Supplier<String> defaultHostSupplier = () -> defaultHost;
+
+    private static final String TRADITIONAL_FRAME_SYSLOG =
+            "<44>1 2022-10-26T10:10:24+00:00 " +
+                    "some-hostname process-name proc-id message-id " +
+                    "[instance@12345 " +
+                    "key1=\"val1\" " +
+                    "key2=\"val2\" " +
+                    "key3=\"val3\"] " +
+                    "Some message";
+
+    private static final String OCTET_COUNT_FRAME_SYSLOG =
+            "129 <14>1 2021-12-24T22:20:01.438069+00:00 " +
+                    "another-hostname another-app-name ABC message-id " +
+                    "[tags@12345 " +
+                    "key1=\"val1\"] " +
+                    "Another message";
+
+    private ReportableEntityDecoder<String, ReportLog> decoder;
+
+    private List<ReportLog> reportLogs;
+
+    @Before
+    public void setup() {
+        reportLogs = new ArrayList<>();
+    }
+
+    @Test
+    public void testTraditionalFrameTypeSyslogMessage() {
+        SyslogDecoder decoder = new SyslogDecoder(defaultHostSupplier, null, null, null, null, null, null, null);
+        decoder.decode(TRADITIONAL_FRAME_SYSLOG, reportLogs, "none", null);
+        assertEquals(1, reportLogs.size());
+
+        ReportLog log = reportLogs.get(0);
+        assertEquals(1666779024000L, log.getTimestamp());
+        assertEquals("Some message", log.getMessage());
+        assertEquals(4, log.getAnnotations().size());
+
+        assertEquals(Annotation.newBuilder().setKey("syslog_host").setValue("some-hostname").build(), log.getAnnotations().get(0));
+        assertEquals(Annotation.newBuilder().setKey("key1").setValue("val1").build(), log.getAnnotations().get(1));
+        assertEquals(Annotation.newBuilder().setKey("key2").setValue("val2").build(), log.getAnnotations().get(2));
+        assertEquals(Annotation.newBuilder().setKey("key3").setValue("val3").build(), log.getAnnotations().get(3));
+    }
+
+    @Test
+    public void testOctetCountFrameTypeSyslogMessage() {
+        SyslogDecoder decoder = new SyslogDecoder(defaultHostSupplier, null, null, null, null, null, null, null);
+        decoder.decode(OCTET_COUNT_FRAME_SYSLOG, reportLogs, "none", null);
+        assertEquals(1, reportLogs.size());
+
+        ReportLog log = reportLogs.get(0);
+        assertEquals(1640384401438L, log.getTimestamp());
+        assertEquals("Another message", log.getMessage());
+        assertEquals("another-hostname", log.getHost());
+        assertEquals(2, log.getAnnotations().size());
+
+        assertEquals(Annotation.newBuilder().setKey("syslog_host").setValue("another-hostname").build(), log.getAnnotations().get(0));
+        assertEquals(Annotation.newBuilder().setKey("key1").setValue("val1").build(), log.getAnnotations().get(1));
+    }
+
+    @Test
+    public void testNoHostUsesDefault() {
+        SyslogDecoder decoder = new SyslogDecoder(defaultHostSupplier, null, null, null, null, null, null, null);
+
+        String customTagsSyslog =
+                "<14>1 2021-12-24T22:20:01.438069+00:00 " +
+                        "- app-name ABC message-id - " +
+                        "Some message";
+
+        decoder.decode(customTagsSyslog, reportLogs, "none", null);
+        assertEquals(1, reportLogs.size());
+
+        ReportLog log = reportLogs.get(0);
+        assertEquals(1640384401438L, log.getTimestamp());
+        assertEquals("Some message", log.getMessage());
+        assertEquals(defaultHostSupplier.get(), log.getHost());
+    }
+
+    @Test
+    public void testNoHostWithNoDefault() {
+        SyslogDecoder decoder = new SyslogDecoder(null, null, null, null, null, null, null, null);
+
+        String customTagsSyslog =
+                "<14>1 2021-12-24T22:20:01.438069+00:00 " +
+                        "- app-name ABC message-id - " +
+                        "Some message";
+
+        decoder.decode(customTagsSyslog, reportLogs, "none", null);
+        assertEquals(1, reportLogs.size());
+
+        ReportLog log = reportLogs.get(0);
+        assertEquals(1640384401438L, log.getTimestamp());
+        assertEquals("Some message", log.getMessage());
+        assertEquals("unknown", log.getHost());
+    }
+
+    @Test
+    public void testCustomTags() {
+        SyslogDecoder decoder = new SyslogDecoder(defaultHostSupplier, Collections.singletonList("customHost"),
+                Collections.singletonList("customTimestamp"), Collections.singletonList("customMessage"),
+                Collections.singletonList("customApplication"), Collections.singletonList("customService"),
+                Collections.singletonList("customLevel"), Collections.singletonList("customException"));
+
+        long curTime = Clock.now();
+        String customTagsSyslog =
+                "<14>1 2021-12-24T22:20:01.438069+00:00 " +
+                        "- app-name ABC message-id " +
+                        "[tags@12345 " +
+                        "customHost=\"custom host\" " +
+                        "customTimestamp=\"" + curTime + "\" " +
+                        "customMessage=\"custom message\" " +
+                        "customApplication=\"custom application\" " +
+                        "customService=\"custom service\" " +
+                        "customLevel=\"custom level\" " +
+                        "customException=\"custom exception\"] " +
+                        "Base message";
+
+        decoder.decode(customTagsSyslog, reportLogs, "none", null);
+        assertEquals(1, reportLogs.size());
+
+        ReportLog log = reportLogs.get(0);
+        // Will be the syslog timestamp due to the syslog parsing library not accepting null for timestamps
+        assertEquals(1640384401438L, log.getTimestamp());
+        // Will be the syslog message due to the syslog parsing library not accepting null for messages
+        assertEquals("Base message", log.getMessage());
+        assertEquals("custom host", log.getHost());
+
+        assertEquals(8, log.getAnnotations().size());
+
+        assertEquals(Annotation.newBuilder().setKey("syslog_host").setValue("-").build(), log.getAnnotations().get(0));
+        // Unlike other custom tags, the custom host tag doesn't get removed when turning it into the top level host field
+        assertEquals(Annotation.newBuilder().setKey("customHost").setValue("custom host").build(), log.getAnnotations().get(1));
+        assertEquals(Annotation.newBuilder().setKey("customTimestamp").setValue(Long.toString(curTime)).build(), log.getAnnotations().get(2));
+        assertEquals(Annotation.newBuilder().setKey("customMessage").setValue("custom message").build(), log.getAnnotations().get(3));
+        assertEquals(Annotation.newBuilder().setKey("application").setValue("custom application").build(), log.getAnnotations().get(4));
+        assertEquals(Annotation.newBuilder().setKey("service").setValue("custom service").build(), log.getAnnotations().get(5));
+        assertEquals(Annotation.newBuilder().setKey("log_level").setValue("custom level").build(), log.getAnnotations().get(6));
+        assertEquals(Annotation.newBuilder().setKey("error_name").setValue("custom exception").build(), log.getAnnotations().get(7));
+    }
+
+    @Test
+    public void testInvalidSyslogMessage() {
+        SyslogDecoder decoder = new SyslogDecoder(defaultHostSupplier, null, null, null, null, null, null, null);
+
+        String notASyslogMessage = "invalid";
+        decoder.decode(notASyslogMessage, reportLogs, "none", null);
+        assertEquals(reportLogs.size(), 1);
+        ReportLog log = reportLogs.get(0);
+        assertNull(log);
+    }
+
+    @Test
+    public void testInvalidOctetCountSyslogMessage() {
+        SyslogDecoder decoder = new SyslogDecoder(defaultHostSupplier, null, null, null, null, null, null, null);
+
+        String invalidOctetCount =
+                "10 <14>1 2021-12-24T22:20:01.438069+00:00 " +
+                        "hostname app-name ABC message-id - " +
+                        "Base message";
+        decoder.decode(invalidOctetCount, reportLogs, "none", null);
+        assertEquals(reportLogs.size(), 1);
+        ReportLog log = reportLogs.get(0);
+        assertNull(log);
+    }
+
+    // This is a valid syslog message, but our parsing library doesn't currently support it
+    @Test
+    public void testInvalidNoTimestampSyslogMessages() {
+        SyslogDecoder decoder = new SyslogDecoder(defaultHostSupplier, null, null, null, null, null, null, null);
+
+        String noTimestamp =
+                "<14>1 - " +
+                        "hostname app-name ABC message-id - " +
+                        "Base message";
+        decoder.decode(noTimestamp, reportLogs, "none", null);
+        assertEquals(reportLogs.size(), 1);
+        ReportLog log = reportLogs.get(0);
+        assertNull(log);
+    }
+
+    // This is a valid syslog message, but our parsing library doesn't currently support it
+    @Test
+    public void testInvalidNoMessageSyslogMessages() {
+        SyslogDecoder decoder = new SyslogDecoder(defaultHostSupplier, null, null, null, null, null, null, null);
+
+        String noMessage =
+                "<14>1 2021-12-24T22:20:01.438069+00:00 " +
+                        "hostname app-name ABC message-id -";
+        decoder.decode(noMessage, reportLogs, "none", null);
+        assertEquals(reportLogs.size(), 1);
+        ReportLog log = reportLogs.get(0);
+        assertNull(log);
+    }
+}

--- a/java-lib/src/test/java/com/wavefront/ingester/SyslogParserTest.java
+++ b/java-lib/src/test/java/com/wavefront/ingester/SyslogParserTest.java
@@ -1,0 +1,144 @@
+package com.wavefront.ingester;
+
+import com.wavefront.data.ParseException;
+import org.junit.Before;
+import org.junit.Test;
+import wavefront.report.Annotation;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class SyslogParserTest {
+    private static final String TRADITIONAL_FRAME_SYSLOG =
+            "<44>1 2022-10-26T10:10:24+00:00 " +
+                    "some-hostname process-name proc-id message-id " +
+                    "[instance@12345 " +
+                    "key1=\"val1\" " +
+                    "key2=\"val2\" " +
+                    "key3=\"val3\"] " +
+                    "Some message";
+
+    private static final String OCTET_COUNT_FRAME_SYSLOG =
+            "129 <14>1 2021-12-24T22:20:01.438069+00:00 " +
+                    "another-hostname another-app-name ABC message-id " +
+                    "[tags@12345 " +
+                    "key1=\"val1\"] " +
+                    "Another message";
+    private SyslogParser parser;
+    private List<Annotation> annotations;
+
+    @Before
+    public void setUp() {
+        parser = new SyslogParser();
+        annotations = new ArrayList<>();
+    }
+
+    @Test
+    public void testTraditionalFrameTypeSyslogMessage() {
+        parser.parse(TRADITIONAL_FRAME_SYSLOG, annotations);
+
+        assertEquals(7, annotations.size());
+
+        assertEquals(Annotation.newBuilder().setKey("timestamp").setValue("1666779024000").build(), annotations.get(0));
+        assertEquals(Annotation.newBuilder().setKey("message").setValue("Some message").build(), annotations.get(1));
+        assertEquals(Annotation.newBuilder().setKey("host").setValue("some-hostname").build(), annotations.get(2));
+        assertEquals(Annotation.newBuilder().setKey("syslog_host").setValue("some-hostname").build(), annotations.get(3));
+
+        assertEquals(Annotation.newBuilder().setKey("key1").setValue("val1").build(), annotations.get(4));
+        assertEquals(Annotation.newBuilder().setKey("key2").setValue("val2").build(), annotations.get(5));
+        assertEquals(Annotation.newBuilder().setKey("key3").setValue("val3").build(), annotations.get(6));
+    }
+
+    @Test
+    public void testOctetCountFrameTypeSyslogMessage() {
+        parser.parse(OCTET_COUNT_FRAME_SYSLOG, annotations);
+
+        assertEquals(5, annotations.size());
+
+        assertEquals(Annotation.newBuilder().setKey("timestamp").setValue("1640384401438").build(), annotations.get(0));
+        assertEquals(Annotation.newBuilder().setKey("message").setValue("Another message").build(), annotations.get(1));
+        assertEquals(Annotation.newBuilder().setKey("host").setValue("another-hostname").build(), annotations.get(2));
+        assertEquals(Annotation.newBuilder().setKey("syslog_host").setValue("another-hostname").build(), annotations.get(3));
+
+        assertEquals(Annotation.newBuilder().setKey("key1").setValue("val1").build(), annotations.get(4));
+    }
+
+    @Test
+    public void testNoHost() {
+        String noHostSyslogMessage = "<14>1 2021-12-24T22:20:01.438069+00:00 - app-name proc-id message-id [tags@12345 key1=val1] message";
+
+        parser.parse(noHostSyslogMessage, annotations);
+
+        assertEquals(3, annotations.size());
+
+        assertEquals(Annotation.newBuilder().setKey("timestamp").setValue("1640384401438").build(), annotations.get(0));
+        assertEquals(Annotation.newBuilder().setKey("message").setValue("message").build(), annotations.get(1));
+        assertEquals(Annotation.newBuilder().setKey("syslog_host").setValue("-").build(), annotations.get(2));
+    }
+
+    @Test
+    public void testNoStructuredData() {
+        String noStructuredDataSyslogMessage = "<14>1 2021-12-24T22:20:01.438069+00:00 hostname app-name proc-id message-id - message";
+
+        parser.parse(noStructuredDataSyslogMessage, annotations);
+
+        assertEquals(4, annotations.size());
+
+        assertEquals(Annotation.newBuilder().setKey("timestamp").setValue("1640384401438").build(), annotations.get(0));
+        assertEquals(Annotation.newBuilder().setKey("message").setValue("message").build(), annotations.get(1));
+        assertEquals(Annotation.newBuilder().setKey("host").setValue("hostname").build(), annotations.get(2));
+        assertEquals(Annotation.newBuilder().setKey("syslog_host").setValue("hostname").build(), annotations.get(3));
+    }
+
+    @Test
+    public void testOctetCountDiffersFromCharacterCount() {
+        // The message character count is 111, but the octet count is 115 due to characters being 1-4 bytes
+        String syslogMessageWithMultibyteCharacters = "115 <44>1 2022-10-26T10:10:24.727681+00:00 some-hostname process-name proc-id message-id [tags@12345 key1=val1] 世界";
+        parser.parse(syslogMessageWithMultibyteCharacters, annotations);
+
+        assertEquals(4, annotations.size());
+
+        assertEquals(Annotation.newBuilder().setKey("timestamp").setValue("1666779024727").build(), annotations.get(0));
+        assertEquals(Annotation.newBuilder().setKey("message").setValue("世界").build(), annotations.get(1));
+        assertEquals(Annotation.newBuilder().setKey("host").setValue("some-hostname").build(), annotations.get(2));
+        assertEquals(Annotation.newBuilder().setKey("syslog_host").setValue("some-hostname").build(), annotations.get(3));
+    }
+
+    @Test
+    public void testOctetCountIsIncorrectlySetToCharacterCountThrowsException() {
+        // The message character count is 111, but the octet count is 115 due to characters being 1-4 bytes
+        String invalidSyslogMessageWithMultibyteCharacters = "111 <44>1 2022-10-26T10:10:24.727681+00:00 some-hostname process-name proc-id message-id [tags@12345 key1=val1] 世界";
+        Exception e = assertThrows(ParseException.class, () -> parser.parse(invalidSyslogMessageWithMultibyteCharacters, annotations));
+        assertEquals("Mismatched syslog message octet count", e.getMessage());
+    }
+
+    // This is a valid syslog message, but our parsing library doesn't currently support it
+    @Test
+    public void testNoTimestampThrowsException() {
+        String noTimestampSyslogMessage = "<44>1 - hostname app-name proc-id - - some message";
+        Exception e = assertThrows(ParseException.class, () -> parser.parse(noTimestampSyslogMessage, annotations));
+        assertEquals("Timestamp is a required syslog field", e.getMessage());
+    }
+
+    // This is a valid syslog message, but our parsing library doesn't currently support it
+    @Test
+    public void testNoMessageThrowsException() {
+        String noMessageSyslogMessage = "<14>1 2021-12-24T22:20:01.438069+00:00 hostname app-name proc-id - -";
+        assertThrows(ParseException.class, () -> parser.parse(noMessageSyslogMessage, annotations));
+    }
+
+    @Test
+    public void testInvalidOctetCountThrowsException() {
+        // Correct octet_count is 85
+        String invalidOctetCountSyslogMessage = "10 <44>1 2022-10-26T10:10:24.727681+00:00 some-hostname process-name - - - Some message";
+        Exception e = assertThrows(ParseException.class, () -> parser.parse(invalidOctetCountSyslogMessage, annotations));
+        assertEquals("Mismatched syslog message octet count", e.getMessage());
+    }
+
+    @Test
+    public void testInvalidSyslogMessageThrowsException() {
+        String invalidSyslogMessage = "invalid data";
+        assertThrows(ParseException.class, () -> parser.parse(invalidSyslogMessage, annotations));
+    }
+}


### PR DESCRIPTION
This PR is part of work done by one of the Wavefront teams in 2022 for Tanzu Application Service logs. In addition to this commit, they have another set of changes that uses this functionality to add syslog support to the Wavefront Proxy.

My team have some components we'd like to monitor that can forward logs to syslog, so we're interested in getting this functionality merged.