### PR TITLE
MONIT-32705: update netty version for cve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <log4j.version>2.15.0</log4j.version>
     <jackson.version>2.13.3</jackson.version>
     <jackson-databind.version>2.13.4.1</jackson-databind.version>
-    <netty.version>4.1.86.Final</netty.version>
+    <netty.version>4.1.89.Final</netty.version>
   </properties>
 
   <build>


### PR DESCRIPTION
[CVE-2022-41881](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-41881) was detected in [java-lib](https://github.com/wavefrontHQ/java-lib).

Updated version to 4.1.86 as per CVE