### PR TITLE
MONIT-40322

### DIFF
--- a/java-lib/pom.xml
+++ b/java-lib/pom.xml
@@ -3,12 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>java-lib</artifactId>
-  <version>2023-04.4-SNAPSHOT</version>
+  <version>2023-07.1-SNAPSHOT</version>
 
   <parent>
     <groupId>com.wavefront</groupId>
     <artifactId>javalib</artifactId>
-    <version>2023-04.4-SNAPSHOT</version>
+    <version>2023-07.1-SNAPSHOT</version>
   </parent>
 
   <name>Wavefront Shared Java Library</name>

--- a/java-lib/src/main/java/com/wavefront/data/Validation.java
+++ b/java-lib/src/main/java/com/wavefront/data/Validation.java
@@ -504,11 +504,6 @@ public class Validation {
       throw new DataValidationException(Validation.LOG_SOURCE_REQUIRED_ERROR);
     }
 
-    if (!config.enableHyperlogsConvergedCsp() && source.length() > config.getHostLengthLimit()) {
-      LOG_ERROR_COUNTERS.get("logSourceTooLong").inc();
-      throw new DataValidationException(String.format(LOG_SOURCE_TOO_LONG_ERROR, source.length(),
-              config.getHostLengthLimit(), source));
-    }
     if (message.length() > config.getLogLengthLimit()) {
       LOG_ERROR_COUNTERS.get("logMessageTooLong").inc();
       throw new DataValidationException(String.format(Validation.LOG_MESSAGE_TOO_LONG_ERROR, message.length(),

--- a/java-lib/src/test/java/com/wavefront/data/ValidationTest.java
+++ b/java-lib/src/test/java/com/wavefront/data/ValidationTest.java
@@ -493,17 +493,6 @@ public class ValidationTest {
     Exception e = assertThrows(DataValidationException.class, () -> Validation.validateLog(nullHostLog, config));
     assertEquals(Validation.LOG_SOURCE_REQUIRED_ERROR, e.getMessage());
 
-    // Test Host Too Long
-    ReportLog hostTooLongLog = getValidLog();
-    StringBuilder hostTooLong = new StringBuilder();
-    for (int i = 0; i < config.getHostLengthLimit() + 1; i++) {
-      hostTooLong.append("a");
-    }
-    hostTooLongLog.setHost(String.valueOf(hostTooLong));
-    e = assertThrows(DataValidationException.class, () -> Validation.validateLog(hostTooLongLog, config));
-    String errorMsg = String.format(Validation.LOG_SOURCE_TOO_LONG_ERROR, (config.getHostLengthLimit() + 1)
-            , config.getHostLengthLimit(), hostTooLong);
-    assertEquals(errorMsg, e.getMessage());
 
     // Test Log Message Too Long
     ReportLog messageTooLongLog = getValidLog();
@@ -513,7 +502,8 @@ public class ValidationTest {
     }
     messageTooLongLog.setMessage(String.valueOf(stringTooLong));
     e = assertThrows(DataValidationException.class, () -> Validation.validateLog(messageTooLongLog, config));
-    errorMsg = String.format(Validation.LOG_MESSAGE_TOO_LONG_ERROR, config.getLogLengthLimit() + 1
+    String errorMsg = String.format(Validation.LOG_MESSAGE_TOO_LONG_ERROR,
+        config.getLogLengthLimit() + 1
             , config.getLogLengthLimit(), messageTooLongLog.getMessage());
     assertEquals(errorMsg, e.getMessage());
 
@@ -599,10 +589,9 @@ public class ValidationTest {
   }
 
   @Test
-  public void testValidLogForCSPTenant() {
+  public void testDoNotValidLogSourceLength() {
     ReportLog hostTooLongLog = getValidLog();
     StringBuilder hostTooLong = new StringBuilder();
-    config.setEnableHyperlogsConvergedCsp(true);
     for (int i = 0; i < config.getHostLengthLimit() + 1; i++) {
       hostTooLong.append("a");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.wavefront</groupId>
   <artifactId>javalib</artifactId>
-  <version>2023-04.4-SNAPSHOT</version>
+  <version>2023-07.1-SNAPSHOT</version>
   <modules>
     <module>java-lib</module>
     <module>yammer-metrics</module>

--- a/yammer-metrics/pom.xml
+++ b/yammer-metrics/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <artifactId>javalib</artifactId>
         <groupId>com.wavefront</groupId>
-        <version>2023-04.4-SNAPSHOT</version>
+        <version>2023-07.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>yammer-metrics</artifactId>
-    <version>2023-04.4-SNAPSHOT</version>
+    <version>2023-07.1-SNAPSHOT</version>
     <name>Wavefront Yammer Metrics</name>
     <dependencies>
         <dependency>


### PR DESCRIPTION
MONIT-40322-Removing `hostLengthLimit` validation for logs. Also, a few pom.xml changes for a new release.